### PR TITLE
Scaffold Next.js 15 stack for Smarter Movie Seating

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Supabase project configuration
+SUPABASE_URL=https://your-supabase-project.supabase.co
+SUPABASE_ANON_KEY=public-anon-key
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
+TMDB_API_KEY=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules
+.next
+.env.local
+.env
+*.log
+.prisma/client
+.vercel
+.DS_Store

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# MovieSelectionApp
+# Smarter Movie Seating (V1)
+
+A modern, type-safe foundation for exploring movie showtimes and comparing the best available seats across nearby theaters. The
+project is built as a single Next.js 15 application that bundles the frontend, backend, and database access layers together for a
+smooth Vercel deployment story.
+
+## Tech stack
+
+- **Framework**: Next.js 15 (App Router, Server Components, Server Actions)
+- **Styling**: Tailwind CSS and shadcn/ui primitives
+- **Data fetching**: TanStack Query + tRPC
+- **Database**: Supabase (Postgres) managed via Prisma ORM
+- **Language**: TypeScript end-to-end
+
+## Getting started
+
+```bash
+pnpm install
+pnpm dlx prisma generate
+pnpm run dev
+```
+
+### Environment variables
+
+Copy the sample configuration and update it with your Supabase project credentials and TMDB token:
+
+```bash
+cp .env.example .env.local
+```
+
+Required variables:
+
+- `SUPABASE_URL`
+- `SUPABASE_ANON_KEY`
+- `DATABASE_URL`
+- `TMDB_API_KEY` (optional – mock data is returned if unset)
+
+### Database
+
+This project uses Prisma migrations. Initialize your Supabase (or local Postgres) database with:
+
+```bash
+pnpm dlx prisma migrate dev
+```
+
+For deployment on Vercel, run `prisma migrate deploy` and ensure the environment variables are configured in the project settings.
+
+## Project structure
+
+```
+app/               # Next.js App Router routes
+components/        # Shared UI components and feature widgets
+lib/               # Utility helpers and TRPC client
+server/            # tRPC routers, Prisma client, Supabase helpers
+prisma/            # Prisma schema and migrations
+```
+
+Key frontend routes include:
+
+- `/movies` – browse movies and open the seating compare workflow
+- `/movie/[id]` – detailed movie page with a CTA to find seats
+- `/compare/[movieId]` – side-by-side seat block comparison across theaters
+
+## Mock data & TODOs
+
+- The tRPC routers return mock movie, showtime, and seat-map data when external services are not configured.
+- `PreferenceModal` persists preferences in Supabase once auth is connected; currently it stores records using the hard-coded
+  `demo-user` identifier.
+- Extend `server/routers/showtimes.ts` with real Supabase queries or third-party data sources for richer showtime coverage.
+- Add more sample seat maps under `mockSeatMaps` in `server/routers/seats.ts` to experiment with the comparison UI.

--- a/app/api/trpc/[trpc]/route.ts
+++ b/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,13 @@
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { createContext } from "../../../../server/trpc";
+import { appRouter } from "../../../../server/root";
+
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req,
+    router: appRouter,
+    createContext: () => createContext(),
+  });
+
+export { handler as GET, handler as POST };

--- a/app/compare/[movieId]/page.tsx
+++ b/app/compare/[movieId]/page.tsx
@@ -1,0 +1,95 @@
+import Link from "next/link";
+import { createCaller } from "../../../server/caller";
+import { SeatMapGrid } from "../../../components/SeatMapGrid";
+import { SeatLegend } from "../../../components/SeatLegend";
+import { Button } from "../../../components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "../../../components/ui/card";
+
+interface ComparePageProps {
+  params: { movieId: string };
+  searchParams?: { partySize?: string };
+}
+
+export default async function ComparePage({ params, searchParams }: ComparePageProps) {
+  const { movieId } = params;
+  const partySize = Number(searchParams?.partySize ?? "2");
+  const caller = await createCaller();
+  const [movie, showtimes] = await Promise.all([
+    caller.movies.byId({ id: movieId }),
+    caller.showtimes.nearby({ movieId, radiusKm: 50 }),
+  ]);
+
+  const comparison = await Promise.all(
+    showtimes.map(async (showtime: any) => {
+      const seatResult = await caller.seats.topBlocks({ showtimeId: showtime.id, partySize });
+      return {
+        showtime,
+        seatResult,
+      };
+    })
+  );
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10">
+      <div className="flex flex-col gap-2">
+        <Link href={`/movie/${movieId}`} className="text-sm text-primary hover:underline">
+          ← Back to movie
+        </Link>
+        <h1 className="text-3xl font-bold">Best seats for {movie?.title ?? "selected movie"}</h1>
+        <p className="text-muted-foreground">
+          Comparing top seat blocks across nearby theaters using your saved preferences. Update the party size by editing the URL
+          query (?partySize=4).
+        </p>
+        <SeatLegend className="mt-2" />
+      </div>
+      <div className="grid gap-6 md:grid-cols-2">
+        {comparison.map(({ showtime, seatResult }) => {
+          const topBlock = seatResult.blocks[0];
+          const score = topBlock?.score ? Math.round(topBlock.score * 100) : null;
+          return (
+            <Card key={showtime.id} className="border-border/80 bg-card/80">
+              <CardHeader>
+                <CardTitle>{showtime.theater?.name ?? "Theater"}</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {new Date(showtime.startAt).toLocaleString()} • {showtime.theater?.city ?? "Unknown city"}
+                </p>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {seatResult.seatMap ? (
+                  <SeatMapGrid
+                    rows={seatResult.seatMap.rows}
+                    cols={seatResult.seatMap.cols}
+                    taken={seatResult.seatMap.taken}
+                    restricted={seatResult.seatMap.restricted ?? []}
+                    highlights={seatResult.blocks.slice(0, 3)}
+                  />
+                ) : (
+                  <p className="text-sm text-muted-foreground">Seat map not available yet. Add one via Prisma.</p>
+                )}
+                {topBlock ? (
+                  <div className="rounded-md border border-border/80 bg-secondary/40 p-3 text-sm text-secondary-foreground">
+                    <p>
+                      Best block: Row {topBlock.row + 1}, Seats {topBlock.col + 1} - {topBlock.col + topBlock.size}
+                    </p>
+                    <p>Score: {score ? `${score}/100 (${topBlock.grade})` : "N/A"}</p>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">No contiguous seats found for the selected party size.</p>
+                )}
+                {showtime.bookingUrl ? (
+                  <Button asChild variant="outline">
+                    <Link href={showtime.bookingUrl} target="_blank" rel="noreferrer">
+                      Book on theater site
+                    </Link>
+                  </Button>
+                ) : (
+                  <p className="text-xs text-muted-foreground">Add a bookingUrl field in the database to deep link bookings.</p>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,34 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 222.2 47.4% 11.2%;
+  --foreground: 210 40% 98%;
+  --card: 222.2 47.4% 11.2%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222.2 47.4% 11.2%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 262.1 83.3% 57.8%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 217.2 32.6% 17.5%;
+  --secondary-foreground: 210 40% 98%;
+  --muted: 217.2 32.6% 17.5%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 210 40% 98%;
+  --accent-foreground: 222.2 47.4% 11.2%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 217.2 32.6% 17.5%;
+  --input: 217.2 32.6% 17.5%;
+  --ring: 262.1 83.3% 57.8%;
+  --radius: 0.75rem;
+}
+
+body {
+  @apply bg-background text-foreground min-h-screen antialiased font-sans;
+}
+
+main {
+  @apply flex flex-col min-h-screen;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import { ReactNode } from "react";
+import "./globals.css";
+import { Providers } from "./providers";
+
+export const metadata: Metadata = {
+  title: "Smarter Movie Seating",
+  description: "Compare the best seats across theaters",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className="min-h-screen bg-background text-foreground">
+        <Providers>
+          <main className="flex-1">{children}</main>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/movie/[id]/page.tsx
+++ b/app/movie/[id]/page.tsx
@@ -1,0 +1,72 @@
+import Image from "next/image";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { createCaller } from "../../../server/caller";
+import { Button } from "../../../components/ui/button";
+import { Card, CardContent } from "../../../components/ui/card";
+
+interface MoviePageProps {
+  params: { id: string };
+}
+
+export default async function MovieDetailPage({ params }: MoviePageProps) {
+  const { id } = params;
+  const caller = await createCaller();
+  const movie = await caller.movies.byId({ id });
+
+  if (!movie) {
+    notFound();
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-4xl flex-col gap-6 px-4 py-10">
+      <Link href="/movies" className="text-sm text-primary hover:underline">
+        ← Back to movies
+      </Link>
+      <Card className="overflow-hidden border-border/80 bg-card/80">
+        <div className="grid gap-6 md:grid-cols-[220px,1fr]">
+          {movie.poster_path ? (
+            <div className="relative h-[330px] w-full">
+              <Image
+                src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+                alt={movie.title}
+                fill
+                className="object-cover"
+              />
+            </div>
+          ) : (
+            <div className="flex h-[330px] items-center justify-center bg-secondary/40 text-secondary-foreground">
+              No image
+            </div>
+          )}
+          <CardContent className="space-y-4 py-6">
+            <div>
+              <h1 className="text-3xl font-semibold">{movie.title}</h1>
+              {movie.tagline && <p className="text-lg text-muted-foreground">{movie.tagline}</p>}
+            </div>
+            {movie.overview && <p className="text-muted-foreground">{movie.overview}</p>}
+            <ul className="text-sm text-muted-foreground">
+              {movie.release_date && <li>Release date: {movie.release_date}</li>}
+              {movie.runtime && <li>Runtime: {movie.runtime} min</li>}
+              {Array.isArray(movie.genres) && movie.genres.length > 0 && (
+                <li>Genres: {movie.genres.map((genre: any) => genre.name).join(", ")}</li>
+              )}
+            </ul>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button asChild>
+                <Link href={`/compare/${movie.id}`}>Find best seats</Link>
+              </Button>
+              {movie.homepage && (
+                <Button asChild variant="outline">
+                  <Link href={movie.homepage} target="_blank" rel="noreferrer">
+                    Official site
+                  </Link>
+                </Button>
+              )}
+            </div>
+          </CardContent>
+        </div>
+      </Card>
+    </section>
+  );
+}

--- a/app/movies/page.tsx
+++ b/app/movies/page.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link";
+import Image from "next/image";
+import { createCaller } from "../../server/caller";
+import { Button } from "../../components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "../../components/ui/card";
+import { PreferenceModal } from "../../components/PreferenceModal";
+
+export const dynamic = "force-dynamic";
+
+export default async function MoviesPage() {
+  const caller = await createCaller();
+  const movies = await caller.movies.list();
+  const results = Array.isArray(movies) ? movies : movies.results;
+
+  return (
+    <section className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-4 py-10">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Now Playing</h1>
+          <p className="text-muted-foreground">Browse movies and find the perfect seats before booking.</p>
+        </div>
+        <PreferenceModal userId="demo-user" />
+      </header>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {results?.length ? (
+          results.map((movie: any) => (
+            <Card key={movie.id} className="flex flex-col overflow-hidden border-border/80 bg-card/70">
+              {movie.poster_path ? (
+                <div className="relative h-72 w-full">
+                  <Image
+                    src={`https://image.tmdb.org/t/p/w500${movie.poster_path}`}
+                    alt={movie.title}
+                    fill
+                    className="object-cover"
+                  />
+                </div>
+              ) : (
+                <div className="flex h-72 items-center justify-center bg-secondary/50 text-secondary-foreground">No image</div>
+              )}
+              <CardHeader>
+                <CardTitle>{movie.title}</CardTitle>
+                {movie.release_date && <CardDescription>Released {movie.release_date}</CardDescription>}
+              </CardHeader>
+              <CardContent className="flex-1">
+                <p className="line-clamp-4 text-sm text-muted-foreground">{movie.overview}</p>
+              </CardContent>
+              <CardFooter className="mt-auto flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">Rating: {movie.vote_average?.toFixed?.(1) ?? "N/A"}</span>
+                <Button asChild>
+                  <Link href={`/movie/${movie.id}`}>View details</Link>
+                </Button>
+              </CardFooter>
+            </Card>
+          ))
+        ) : (
+          <p className="text-sm text-muted-foreground">No movies available yet. Configure TMDb or add more mock data.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function HomePage() {
+  redirect("/movies");
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+import { httpBatchLink, loggerLink } from "@trpc/client";
+import superjson from "superjson";
+import { trpc } from "../lib/trpc/client";
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  const [trpcClient] = useState(() =>
+    trpc.createClient({
+      transformer: superjson,
+      links: [
+        loggerLink({
+          enabled: (opts) =>
+            process.env.NODE_ENV === "development" || (opts.direction === "down" && opts.result instanceof Error),
+        }),
+        httpBatchLink({
+          url: "/api/trpc",
+        }),
+      ],
+    })
+  );
+
+  return (
+    <trpc.Provider client={trpcClient} queryClient={queryClient}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </trpc.Provider>
+  );
+}

--- a/components/PreferenceModal.tsx
+++ b/components/PreferenceModal.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } from "./ui/dialog";
+import { Button } from "./ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "./ui/select";
+import { trpc } from "../lib/trpc/client";
+
+const zones = [
+  { value: "front", label: "Front" },
+  { value: "mid", label: "Middle" },
+  { value: "back", label: "Back" },
+];
+
+interface PreferenceModalProps {
+  userId: string;
+}
+
+export function PreferenceModal({ userId }: PreferenceModalProps) {
+  const [open, setOpen] = useState(false);
+  const utils = trpc.useUtils();
+  const prefsQuery = trpc.prefs.get.useQuery({ userId }, { enabled: open });
+  const saveMutation = trpc.prefs.save.useMutation({
+    onSuccess: async () => {
+      await utils.prefs.get.invalidate({ userId });
+      setOpen(false);
+    },
+  });
+
+  const basePrefs = useMemo(
+    () => ({
+      zone: "mid",
+      timeStart: 18,
+      timeEnd: 22,
+      radiusKm: 25,
+      partySize: 2,
+    }),
+    []
+  );
+
+  const prefs = prefsQuery.data ?? basePrefs;
+  const [zone, setZone] = useState(prefs.zone);
+
+  useEffect(() => {
+    if (open) {
+      setZone(prefs.zone ?? basePrefs.zone);
+    }
+  }, [open, prefs.zone, basePrefs.zone]);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="secondary">Seating Preferences</Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogTitle>Customize your preferences</DialogTitle>
+        <DialogDescription>
+          Save your favorite seating zone, showtime window, travel radius, and party size. These preferences are persisted in
+          Supabase.
+        </DialogDescription>
+        <form
+          className="mt-4 space-y-4"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const form = new FormData(event.currentTarget);
+            saveMutation.mutate({
+              userId,
+              zone,
+              timeStart: Number(form.get("timeStart") ?? prefs.timeStart),
+              timeEnd: Number(form.get("timeEnd") ?? prefs.timeEnd),
+              radiusKm: Number(form.get("radiusKm") ?? prefs.radiusKm),
+              partySize: Number(form.get("partySize") ?? prefs.partySize),
+            });
+          }}
+        >
+          <input type="hidden" name="zone" value={zone} />
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <label className="space-y-2 text-sm">
+              <span className="text-muted-foreground">Preferred zone</span>
+              <Select value={zone} onValueChange={setZone}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select zone" />
+                </SelectTrigger>
+                <SelectContent>
+                  {zones.map((zoneOption) => (
+                    <SelectItem key={zoneOption.value} value={zoneOption.value}>
+                      {zoneOption.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </label>
+            <label className="space-y-2 text-sm">
+              <span className="text-muted-foreground">Time window start (24h)</span>
+              <input
+                name="timeStart"
+                type="number"
+                min={0}
+                max={23}
+                defaultValue={prefs.timeStart}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </label>
+            <label className="space-y-2 text-sm">
+              <span className="text-muted-foreground">Time window end (24h)</span>
+              <input
+                name="timeEnd"
+                type="number"
+                min={0}
+                max={23}
+                defaultValue={prefs.timeEnd}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </label>
+            <label className="space-y-2 text-sm">
+              <span className="text-muted-foreground">Radius (km)</span>
+              <input
+                name="radiusKm"
+                type="number"
+                min={1}
+                max={200}
+                defaultValue={prefs.radiusKm}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </label>
+            <label className="space-y-2 text-sm">
+              <span className="text-muted-foreground">Party size</span>
+              <input
+                name="partySize"
+                type="number"
+                min={1}
+                max={10}
+                defaultValue={prefs.partySize}
+                className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </label>
+          </div>
+          <Button type="submit" className="w-full" disabled={saveMutation.isPending}>
+            {saveMutation.isPending ? "Saving..." : "Save preferences"}
+          </Button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/SeatLegend.tsx
+++ b/components/SeatLegend.tsx
@@ -1,0 +1,21 @@
+import { cn } from "../lib/utils";
+
+const legendItems = [
+  { label: "Available", className: "bg-emerald-500" },
+  { label: "Taken", className: "bg-rose-500" },
+  { label: "Restricted", className: "bg-stone-500" },
+  { label: "Highlighted", className: "bg-primary" },
+];
+
+export function SeatLegend({ className }: { className?: string }) {
+  return (
+    <div className={cn("flex flex-wrap gap-4 text-sm text-muted-foreground", className)}>
+      {legendItems.map((item) => (
+        <div key={item.label} className="flex items-center gap-2">
+          <span className={cn("h-3 w-3 rounded", item.className)} />
+          <span>{item.label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/SeatMapGrid.tsx
+++ b/components/SeatMapGrid.tsx
@@ -1,0 +1,51 @@
+import { SeatBlock } from "../lib/seatScore";
+import { cn } from "../lib/utils";
+
+interface SeatMapGridProps {
+  rows: number;
+  cols: number;
+  taken?: number[][];
+  restricted?: number[][];
+  highlights?: SeatBlock[];
+}
+
+export function SeatMapGrid({ rows, cols, taken = [], restricted = [], highlights = [] }: SeatMapGridProps) {
+  const takenSet = new Set(taken.map(([r, c]) => `${r}-${c}`));
+  const restrictedSet = new Set(restricted.map(([r, c]) => `${r}-${c}`));
+  const highlightSet = new Set<string>();
+
+  highlights.forEach((block) => {
+    for (let offset = 0; offset < block.size; offset++) {
+      highlightSet.add(`${block.row}-${block.col + offset}`);
+    }
+  });
+
+  return (
+    <div className="grid gap-1" style={{ gridTemplateRows: `repeat(${rows}, minmax(0, 1fr))` }}>
+      {Array.from({ length: rows }).map((_, row) => (
+        <div key={row} className="grid gap-1" style={{ gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))` }}>
+          {Array.from({ length: cols }).map((_, col) => {
+            const key = `${row}-${col}`;
+            const isTaken = takenSet.has(key);
+            const isRestricted = restrictedSet.has(key);
+            const isHighlighted = highlightSet.has(key);
+            return (
+              <div
+                key={col}
+                className={cn(
+                  "aspect-square rounded-sm border border-transparent",
+                  isHighlighted && "bg-primary",
+                  isTaken && "bg-rose-500",
+                  isRestricted && "bg-stone-500",
+                  !isTaken && !isRestricted && !isHighlighted && "bg-emerald-600/70",
+                  "transition-colors"
+                )}
+                title={`Row ${row + 1}, Seat ${col + 1}`}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+import { cn } from "../../lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button";
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+});
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import * as React from "react";
+import { cn } from "../../lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("rounded-lg border border-border bg-card text-card-foreground shadow", className)} {...props} />
+));
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex flex-col space-y-1.5 p-6", className)} {...props} />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  )
+);
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter };

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+const Dialog = DialogPrimitive.Root;
+const DialogTrigger = DialogPrimitive.Trigger;
+const DialogPortal = DialogPrimitive.Portal;
+const DialogClose = DialogPrimitive.Close;
+const DialogTitle = DialogPrimitive.Title;
+const DialogDescription = DialogPrimitive.Description;
+
+const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>(
+  ({ className, ...props }, ref) => (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className={cn("fixed inset-0 z-50 bg-black/80 backdrop-blur-sm", className)}
+      {...props}
+    />
+  )
+);
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(
+  ({ className, children, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border bg-background p-6 shadow-lg duration-200",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+);
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export { Dialog, DialogTrigger, DialogContent, DialogClose, DialogTitle, DialogDescription };

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+import { cn } from "../../lib/utils";
+
+const Select = SelectPrimitive.Root;
+const SelectGroup = SelectPrimitive.Group;
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Trigger>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>>(
+  ({ className, children, ...props }, ref) => (
+    <SelectPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <SelectPrimitive.Icon asChild>
+        <ChevronDown className="h-4 w-4 opacity-50" />
+      </SelectPrimitive.Icon>
+    </SelectPrimitive.Trigger>
+  )
+);
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectContent = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Content>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>>(
+  ({ className, children, position = "popper", ...props }, ref) => (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        className={cn(
+          "relative z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-popover text-popover-foreground shadow-md",
+          position === "popper" && "translate-y-1",
+          className
+        )}
+        position={position}
+        {...props}
+      >
+        <SelectPrimitive.ScrollUpButton className="flex cursor-default items-center justify-center py-1 text-muted-foreground">
+          <ChevronUp className="h-4 w-4" />
+        </SelectPrimitive.ScrollUpButton>
+        <SelectPrimitive.Viewport className="p-1">{children}</SelectPrimitive.Viewport>
+        <SelectPrimitive.ScrollDownButton className="flex cursor-default items-center justify-center py-1 text-muted-foreground">
+          <ChevronDown className="h-4 w-4" />
+        </SelectPrimitive.ScrollDownButton>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  )
+);
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Label>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>>(
+  ({ className, ...props }, ref) => (
+    <SelectPrimitive.Label ref={ref} className={cn("px-2 py-1.5 text-sm font-semibold", className)} {...props} />
+  )
+);
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Item>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>>(
+  ({ className, children, ...props }, ref) => (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+);
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Separator>, React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>>(
+  ({ className, ...props }, ref) => (
+    <SelectPrimitive.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />
+  )
+);
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export { Select, SelectGroup, SelectValue, SelectTrigger, SelectContent, SelectLabel, SelectItem, SelectSeparator };

--- a/lib/distance.ts
+++ b/lib/distance.ts
@@ -1,0 +1,22 @@
+const EARTH_RADIUS_KM = 6371;
+
+function toRadians(value: number) {
+  return (value * Math.PI) / 180;
+}
+
+export function haversineDistanceKm(
+  origin: { lat: number; lon: number },
+  destination: { lat: number; lon: number }
+) {
+  const dLat = toRadians(destination.lat - origin.lat);
+  const dLon = toRadians(destination.lon - origin.lon);
+  const lat1 = toRadians(origin.lat);
+  const lat2 = toRadians(destination.lat);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(lat1) * Math.cos(lat2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return EARTH_RADIUS_KM * c;
+}

--- a/lib/seatScore.ts
+++ b/lib/seatScore.ts
@@ -1,0 +1,93 @@
+export type SeatGrade = "A" | "A-" | "B+" | "B" | "C";
+
+export interface SeatBlock {
+  id: string;
+  row: number;
+  col: number;
+  size: number;
+  score: number;
+  grade: SeatGrade;
+}
+
+interface SeatScoreOptions {
+  rows: number;
+  cols: number;
+  taken: number[][];
+  restricted?: number[][];
+  partySize: number;
+  preferredZones?: { rowStart: number; rowEnd: number }[];
+}
+
+const gradeThresholds: [SeatGrade, number][] = [
+  ["A", 0.85],
+  ["A-", 0.75],
+  ["B+", 0.65],
+  ["B", 0.5],
+  ["C", 0],
+];
+
+function toGrade(score: number): SeatGrade {
+  return gradeThresholds.find(([, threshold]) => score >= threshold)?.[0] ?? "C";
+}
+
+export function scoreSeatMap(options: SeatScoreOptions) {
+  const { rows, cols, taken, restricted = [], partySize, preferredZones = [] } = options;
+  const blocks: SeatBlock[] = [];
+
+  const restrictedSet = new Set(restricted.map(([r, c]) => `${r}-${c}`));
+  const takenSet = new Set(taken.map(([r, c]) => `${r}-${c}`));
+
+  for (let row = 0; row < rows; row++) {
+    let consecutive = 0;
+    for (let col = 0; col < cols; col++) {
+      const key = `${row}-${col}`;
+      if (takenSet.has(key) || restrictedSet.has(key)) {
+        consecutive = 0;
+        continue;
+      }
+      consecutive += 1;
+      if (consecutive >= partySize) {
+        const startCol = col - partySize + 1;
+        const score = computeBlockScore({ row, startCol, partySize, rows, cols, preferredZones });
+        blocks.push({
+          id: `${row}-${startCol}`,
+          row,
+          col: startCol,
+          size: partySize,
+          score,
+          grade: toGrade(score),
+        });
+      }
+    }
+  }
+
+  blocks.sort((a, b) => b.score - a.score);
+  return blocks;
+}
+
+function computeBlockScore({
+  row,
+  startCol,
+  partySize,
+  rows,
+  cols,
+  preferredZones,
+}: {
+  row: number;
+  startCol: number;
+  partySize: number;
+  rows: number;
+  cols: number;
+  preferredZones: { rowStart: number; rowEnd: number }[];
+}) {
+  const centerCol = (cols - 1) / 2;
+  const blockCenter = startCol + (partySize - 1) / 2;
+  const horizontalProximity = 1 - Math.min(Math.abs(blockCenter - centerCol) / centerCol, 1);
+  const verticalProximity = 1 - row / rows;
+
+  const zoneBoost = preferredZones.some((zone) => row >= zone.rowStart && row <= zone.rowEnd)
+    ? 0.1
+    : 0;
+
+  return Number((0.6 * horizontalProximity + 0.3 * verticalProximity + zoneBoost).toFixed(4));
+}

--- a/lib/trpc/client.ts
+++ b/lib/trpc/client.ts
@@ -1,0 +1,6 @@
+"use client";
+
+import { createTRPCReact } from "@trpc/react-query";
+import type { AppRouter } from "../../server/root";
+
+export const trpc = createTRPCReact<AppRouter>();

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,17 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  experimental: {
+    serverActions: true,
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "image.tmdb.org",
+      },
+    ],
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "smarter-movie-seating",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "postinstall": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.21.1",
+    "@supabase/supabase-js": "^2.48.0",
+    "@tanstack/react-query": "^5.59.10",
+    "@trpc/client": "^11.0.0-rc.482",
+    "@trpc/react-query": "^11.0.0-rc.482",
+    "@trpc/server": "^11.0.0-rc.482",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.453.0",
+    "next": "15.0.0-canary.122",
+    "react": "19.0.0-rc-1",
+    "react-dom": "19.0.0-rc-1",
+    "superjson": "^2.2.1",
+    "zod": "^3.23.8",
+    "tailwindcss-animate": "^1.0.7",
+    "@radix-ui/react-slot": "^1.0.4",
+    "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-select": "^1.2.2",
+    "@radix-ui/react-label": "^2.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.1",
+    "@types/react": "^19.0.4",
+    "@types/react-dom": "^19.0.2",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.1",
+    "eslint-config-next": "15.0.0-canary.122",
+    "postcss": "^8.4.49",
+    "prisma": "^5.21.1",
+    "tailwind-merge": "^2.5.2",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,45 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Theater {
+  id     String  @id @default(cuid())
+  name   String
+  city   String
+  lat    Float
+  lon    Float
+  shows  Showtime[]
+}
+
+model Showtime {
+  id        String   @id @default(cuid())
+  movieId   String
+  theaterId String
+  startAt   DateTime
+  theater   Theater  @relation(fields: [theaterId], references: [id])
+  seatMap   SeatMap?
+}
+
+model SeatMap {
+  id          String   @id @default(cuid())
+  showtimeId  String   @unique
+  rows        Int
+  cols        Int
+  taken       Json
+  restricted  Json?
+  showtime    Showtime @relation(fields: [showtimeId], references: [id])
+}
+
+model UserPref {
+  userId    String @id
+  zone      String
+  timeStart Int
+  timeEnd   Int
+  radiusKm  Int
+  partySize Int
+}

--- a/server/caller.ts
+++ b/server/caller.ts
@@ -1,0 +1,7 @@
+import { appRouter } from "./root";
+import { createContext } from "./trpc";
+
+export async function createCaller() {
+  const ctx = await createContext();
+  return appRouter.createCaller(ctx);
+}

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,26 @@
+import { PrismaClient } from "@prisma/client";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ["error", "warn"],
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+const supabaseUrl = process.env.SUPABASE_URL;
+const supabaseKey = process.env.SUPABASE_ANON_KEY;
+
+export const supabase: SupabaseClient | null =
+  supabaseUrl && supabaseKey
+    ? createClient(supabaseUrl, supabaseKey, {
+        auth: { persistSession: false },
+      })
+    : null;

--- a/server/root.ts
+++ b/server/root.ts
@@ -1,0 +1,14 @@
+import { router } from "./trpc";
+import { moviesRouter } from "./routers/movies";
+import { showtimesRouter } from "./routers/showtimes";
+import { seatsRouter } from "./routers/seats";
+import { prefsRouter } from "./routers/prefs";
+
+export const appRouter = router({
+  movies: moviesRouter,
+  showtimes: showtimesRouter,
+  seats: seatsRouter,
+  prefs: prefsRouter,
+});
+
+export type AppRouter = typeof appRouter;

--- a/server/routers/movies.ts
+++ b/server/routers/movies.ts
@@ -1,0 +1,89 @@
+import { z } from "zod";
+import { publicProcedure, router } from "../trpc";
+
+const TMDB_API_URL = "https://api.themoviedb.org/3";
+
+export const moviesRouter = router({
+  list: publicProcedure
+    .input(
+      z
+        .object({
+          query: z.string().optional(),
+        })
+        .optional()
+    )
+    .query(async ({ input }) => {
+      if (!process.env.TMDB_API_KEY) {
+        return {
+          source: "mock",
+          results: mockMovies,
+          note: "TMDB_API_KEY not set. Returning mock data.",
+        };
+      }
+
+      const search = input?.query?.trim();
+      const endpoint = search ? `/search/movie?query=${encodeURIComponent(search)}` : "/movie/now_playing";
+      const response = await fetch(`${TMDB_API_URL}${endpoint}`, {
+        headers: {
+          Authorization: `Bearer ${process.env.TMDB_API_KEY}`,
+          "Content-Type": "application/json;charset=utf-8",
+        },
+        next: { revalidate: 60 },
+      });
+
+      if (!response.ok) {
+        return {
+          source: "mock",
+          results: mockMovies,
+          note: "TMDB request failed. Returning mock data.",
+        };
+      }
+
+      const data = await response.json();
+      return {
+        source: "tmdb",
+        results: data.results ?? [],
+      };
+    }),
+
+  byId: publicProcedure
+    .input(z.object({ id: z.string() }))
+    .query(async ({ input }) => {
+      if (!process.env.TMDB_API_KEY) {
+        return mockMovies.find((movie) => String(movie.id) === input.id) ?? null;
+      }
+
+      const response = await fetch(`${TMDB_API_URL}/movie/${input.id}`, {
+        headers: {
+          Authorization: `Bearer ${process.env.TMDB_API_KEY}`,
+          "Content-Type": "application/json;charset=utf-8",
+        },
+        next: { revalidate: 300 },
+      });
+
+      if (!response.ok) {
+        return mockMovies.find((movie) => String(movie.id) === input.id) ?? null;
+      }
+
+      return response.json();
+    }),
+});
+
+const mockMovies = [
+  {
+    id: 603692,
+    title: "John Wick: Chapter 4",
+    overview: "With the price on his head ever increasing, John Wick uncovers a path to defeating The High Table.",
+    poster_path: "/vZloFAK7NmvMGKE7VkF5UHaz0I.jpg",
+    vote_average: 7.8,
+    release_date: "2023-03-22",
+  },
+  {
+    id: 569094,
+    title: "Spider-Man: Across the Spider-Verse",
+    overview: "Miles Morales catapults across the Multiverse, where he encounters a team of Spider-People charged with protecting its very existence.",
+    poster_path: "/8Vt6mWEReuy4Of61Lnj5Xj704m8.jpg",
+    vote_average: 8.4,
+    release_date: "2023-05-31",
+  },
+];

--- a/server/routers/prefs.ts
+++ b/server/routers/prefs.ts
@@ -1,0 +1,60 @@
+import { z } from "zod";
+import { prisma } from "../db";
+import { publicProcedure, router } from "../trpc";
+
+const prefsSchema = z.object({
+  userId: z.string(),
+  zone: z.string().default("mid"),
+  timeStart: z.number().int().min(0).max(23).default(18),
+  timeEnd: z.number().int().min(0).max(23).default(22),
+  radiusKm: z.number().int().min(1).max(200).default(25),
+  partySize: z.number().int().min(1).max(10).default(2),
+});
+
+const defaultPrefs = {
+  zone: "mid",
+  timeStart: 18,
+  timeEnd: 22,
+  radiusKm: 25,
+  partySize: 2,
+};
+
+function databaseReady() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export const prefsRouter = router({
+  get: publicProcedure
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ input }) => {
+      if (!databaseReady()) {
+        return { userId: input.userId, ...defaultPrefs };
+      }
+
+      try {
+        const pref = await prisma.userPref.findUnique({ where: { userId: input.userId } });
+        return pref ?? { userId: input.userId, ...defaultPrefs };
+      } catch (error) {
+        console.warn("prefs.get failed", error);
+        return { userId: input.userId, ...defaultPrefs };
+      }
+    }),
+  save: publicProcedure.input(prefsSchema).mutation(async ({ input }) => {
+    if (!databaseReady()) {
+      console.warn("Skipping preference persistence because DATABASE_URL is not configured.");
+      return { ...defaultPrefs, userId: input.userId, ...input };
+    }
+
+    try {
+      const pref = await prisma.userPref.upsert({
+        where: { userId: input.userId },
+        update: input,
+        create: input,
+      });
+      return pref;
+    } catch (error) {
+      console.error("prefs.save failed", error);
+      throw error;
+    }
+  }),
+});

--- a/server/routers/seats.ts
+++ b/server/routers/seats.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import { prisma } from "../db";
+import { publicProcedure, router } from "../trpc";
+import { scoreSeatMap } from "../../lib/seatScore";
+
+function databaseReady() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export const seatsRouter = router({
+  topBlocks: publicProcedure
+    .input(
+      z.object({
+        showtimeId: z.string(),
+        partySize: z.number().min(1).max(10).default(2),
+      })
+    )
+    .query(async ({ input }) => {
+      if (!databaseReady()) {
+        const mock = mockSeatMaps.find((map) => map.showtimeId === input.showtimeId);
+        if (!mock) {
+          return { seatMap: null, blocks: [] };
+        }
+        return {
+          seatMap: {
+            rows: mock.rows,
+            cols: mock.cols,
+            taken: mock.taken,
+            restricted: mock.restricted,
+          },
+          blocks: scoreSeatMap({
+            rows: mock.rows,
+            cols: mock.cols,
+            taken: mock.taken,
+            restricted: mock.restricted,
+            partySize: input.partySize,
+            preferredZones: mock.preferredZones,
+          }),
+        };
+      }
+
+      const seatMap = await prisma.seatMap.findUnique({
+        where: { showtimeId: input.showtimeId },
+      });
+
+      if (!seatMap) {
+        const mock = mockSeatMaps.find((map) => map.showtimeId === input.showtimeId);
+        if (!mock) return { seatMap: null, blocks: [] };
+        return {
+          seatMap: {
+            rows: mock.rows,
+            cols: mock.cols,
+            taken: mock.taken,
+            restricted: mock.restricted,
+          },
+          blocks: scoreSeatMap({
+            rows: mock.rows,
+            cols: mock.cols,
+            taken: mock.taken,
+            restricted: mock.restricted,
+            partySize: input.partySize,
+            preferredZones: mock.preferredZones,
+          }),
+        };
+      }
+
+      const taken = seatMap.taken as number[][];
+      const restricted = (seatMap.restricted as number[][] | null) ?? [];
+
+      return {
+        seatMap: {
+          rows: seatMap.rows,
+          cols: seatMap.cols,
+          taken,
+          restricted,
+        },
+        blocks: scoreSeatMap({
+          rows: seatMap.rows,
+          cols: seatMap.cols,
+          taken,
+          restricted,
+          partySize: input.partySize,
+        }),
+      };
+    }),
+});
+
+const mockSeatMaps = [
+  {
+    id: "mock-seatmap-1",
+    showtimeId: "mock-showtime-1",
+    rows: 12,
+    cols: 18,
+    taken: [
+      [5, 8],
+      [5, 9],
+      [6, 8],
+      [6, 9],
+    ],
+    restricted: [
+      [0, 0],
+      [0, 1],
+      [0, 16],
+      [0, 17],
+    ],
+    preferredZones: [
+      { rowStart: 4, rowEnd: 7 },
+    ],
+  },
+];

--- a/server/routers/showtimes.ts
+++ b/server/routers/showtimes.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+import { prisma } from "../db";
+import { publicProcedure, router } from "../trpc";
+import { haversineDistanceKm } from "../../lib/distance";
+
+function databaseReady() {
+  return Boolean(process.env.DATABASE_URL);
+}
+
+export const showtimesRouter = router({
+  nearby: publicProcedure
+    .input(
+      z.object({
+        movieId: z.string(),
+        userLocation: z
+          .object({
+            lat: z.number(),
+            lon: z.number(),
+          })
+          .optional(),
+        radiusKm: z.number().min(1).max(200).default(25),
+      })
+    )
+    .query(async ({ input }) => {
+      const { movieId, userLocation, radiusKm } = input;
+
+      if (!databaseReady()) {
+        return mockShowtimes.filter((show) => show.movieId === movieId);
+      }
+
+      const showtimes = await prisma.showtime.findMany({
+        where: { movieId },
+        include: { theater: true },
+        take: 25,
+      });
+
+      if (showtimes.length === 0) {
+        return mockShowtimes.filter((show) => show.movieId === movieId);
+      }
+
+      if (!userLocation) {
+        return showtimes;
+      }
+
+      return showtimes.filter((show) => {
+        const distance = haversineDistanceKm(userLocation, {
+          lat: show.theater.lat,
+          lon: show.theater.lon,
+        });
+        return distance <= radiusKm;
+      });
+    }),
+});
+
+const mockShowtimes = [
+  {
+    id: "mock-showtime-1",
+    movieId: "603692",
+    theaterId: "mock-theater-1",
+    startAt: new Date().toISOString(),
+    theater: {
+      id: "mock-theater-1",
+      name: "Downtown Cinema 12",
+      city: "San Francisco",
+      lat: 37.7858,
+      lon: -122.4064,
+    },
+  },
+];

--- a/server/trpc.ts
+++ b/server/trpc.ts
@@ -1,0 +1,15 @@
+import { initTRPC } from "@trpc/server";
+import superjson from "superjson";
+import type { NextRequest } from "next/server";
+
+export const createContext = async (_req?: NextRequest) => ({
+  // TODO: Add authenticated user context when Supabase auth is wired up.
+  user: null as null,
+});
+
+const t = initTRPC.context<typeof createContext>().create({
+  transformer: superjson,
+});
+
+export const router = t.router;
+export const publicProcedure = t.procedure;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,62 @@
+import type { Config } from "tailwindcss";
+import { fontFamily } from "tailwindcss/defaultTheme";
+import animate from "tailwindcss-animate";
+
+const config: Config = {
+  darkMode: ["class"],
+  content: [
+    "./app/**/*.{ts,tsx}",
+    "./components/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)", ...fontFamily.sans],
+      },
+    },
+  },
+  plugins: [animate],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 15 + Tailwind + shadcn/ui application shell with TypeScript tooling and Supabase/Prisma wiring
- add tRPC routers, utilities, and Prisma schema that expose movies, showtimes, seat scoring, and preference persistence with mock fallbacks
- implement movie browsing, detail, and comparison routes alongside reusable seat visualization and preference components

## Testing
- `pnpm install` *(fails: 403 Forbidden from registry in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e54e5175bc8322bb59af81b76ec2c7